### PR TITLE
Add Mocodo to Entity-Relationship diagramming tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,7 @@ Specifically for BPMN: https://bpmn.io/
 
 - https://dbdiagram.io/home which also has an open-source markup language: https://github.com/holistics/dbml
 - [Databasediagram.com – Private, Text to Entity-Relationship Diagram Tool](https://news.ycombinator.com/item?id=36243926)
+- [Mocodo](https://mocodo.net): French-flavored ERD, aka Merise MCD, where the layout is constrained to a grid
 
 ### Cloud Architecture diagrams
 


### PR DESCRIPTION
My own tool adopts a mixed approach to the layout problem : diagram-as-text, but the line breaks and the order of the boxes (entities and relations) are used as position hints. The resulting layout is constrained to an invisible grid corresponding to a left-to-right and top-to-down reading of the source.

Moreover, since there are relatively few possible grid positions, automatically rearranging the layout becomes an assignment problem, which can be solved by a simple b&b algorithm.

Obviously, this wouldn't scale, but this is just a teaching tool that I use to present small ERDs to my students.

You may test it at https://mocodo.net/. Click the turning arrows symbol to draw the diagram and the shuffle symbol to rearrange it randomly.

Warning: French-flavored ERD, aka Merise MCD.