### PR TITLE
Added https://az-icons.com for Azure icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,7 @@ other boilerplates to use
 - https://iconsear.ch/ instant search of 50k svg icons from GitHub and GitLab
 - https://macosicons.com/ icons intended to replace mac desktop icons
 - https://awsicons.dev/ AWS icons and https://aws-icons.com/
+- https://az-icons.com/ Azure icons
 
 #### General & Misc
 


### PR DESCRIPTION
Added az-icons under Icons and Logos. An open site with all the Azure logos exportable and SVG and PNG.

[https://az-icons.com](https://az-icons.com)