### PR TITLE
docs: update Chrome Web Store URL to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ more control in exchange for more work on your part.
 - https://github.com/jackdomleo7/Checka11y.css
 - https://ffoodd.github.io/a11y.css/
 - https://github.com/mike-engel/a11y-css-reset
-- chrome extension https://chrome.google.com/webstore/detail/a11ycss/iolfinldndiiobhednboghogkiopppid?hl=en
+- chrome extension https://chromewebstore.google.com/detail/a11ycss/iolfinldndiiobhednboghogkiopppid?hl=en
 
 ### Tailwind Component Libraries
 


### PR DESCRIPTION
## Summary
- Updated 1 Chrome Web Store URL from `chrome.google.com/webstore/detail/` to `chromewebstore.google.com/detail/` in README.md
- Google migrated the Chrome Web Store to a new domain; the old URLs currently redirect but may stop working in the future

## Test plan
- [x] Verified updated URL resolves correctly
- [x] No functional changes, docs-only update